### PR TITLE
Removed ssh & git from container in favor of bind mounts

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -4,6 +4,3 @@ MC_VERSION=
 # (Required) Forge version.
 # Sets the Minecraft server Forge version. If REPO variable is empty, this is used to get the correct Forge MDK files.
 FORGE_VERSION=
-# (Optional) GitHub url for cloning a repository via SSH. Info on setting up SSH with GitHub: https://docs.github.com/en/authentication/connecting-to-github-with-ssh
-# Sets the GitHub repo to copy into the development container. If set, the development container will use the contents of the repository instead of a fresh Forge MDK install.
-REPO=

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,26 +2,19 @@ FROM ubuntu:latest
 ARG MC_VERSION
 ARG FORGE_VERSION
 ARG REPO
-RUN --mount=type=ssh apt-get update \
-    && apt-get install -y wget \
+ENV HOME /usr/local/proj
+
+RUN apt-get update
+RUN apt-get install -y wget \
     && wget -P /usr/local "https://download.oracle.com/java/17/archive/jdk-17.0.9_linux-x64_bin.deb" \
     && dpkg -i /usr/local/jdk-17.0.9_linux-x64_bin.deb \
     && apt-get install -f -y \
-    && rm /usr/local/jdk-17.0.9_linux-x64_bin.deb \
-    && apt-get install -y git \
-    && apt-get install -y openssh-client \
-    && if test -n "$REPO" ; then \
-    mkdir -p -m 0400 ~/.ssh \
-    && ssh-keyscan github.com >> ~/.ssh/known_hosts \
-    && git clone $REPO /usr/local/proj/ ;\
-    else \
-    mkdir /usr/local/proj \
+    && rm /usr/local/jdk-17.0.9_linux-x64_bin.deb
+RUN mkdir $HOME \
     && apt-get install -y unzip \
-    && wget -P /usr/local/proj "https://maven.minecraftforge.net/net/minecraftforge/forge/$MC_VERSION-$FORGE_VERSION/forge-$MC_VERSION-$FORGE_VERSION-mdk.zip" \
-    && unzip /usr/local/proj/forge-$MC_VERSION-$FORGE_VERSION-mdk.zip -d /usr/local/proj \
-    && rm /usr/local/proj/forge-$MC_VERSION-$FORGE_VERSION-mdk.zip ; \
-    fi
-WORKDIR /usr/local/proj
-RUN ./gradlew build
+    && wget -P $HOME "https://maven.minecraftforge.net/net/minecraftforge/forge/$MC_VERSION-$FORGE_VERSION/forge-$MC_VERSION-$FORGE_VERSION-mdk.zip" \
+    && unzip $HOME/forge-$MC_VERSION-$FORGE_VERSION-mdk.zip -d $HOME \
+    && rm $HOME/forge-$MC_VERSION-$FORGE_VERSION-mdk.zip ;
+WORKDIR $HOME
 # Keep container running (for use in VSCode)
 CMD [ "tail", "-f", "/dev/null" ]

--- a/com/example/examplemod/Config.java
+++ b/com/example/examplemod/Config.java
@@ -1,0 +1,64 @@
+package com.example.examplemod;
+
+import net.minecraft.resources.ResourceLocation;
+import net.minecraft.world.item.Item;
+import net.minecraftforge.common.ForgeConfigSpec;
+import net.minecraftforge.eventbus.api.SubscribeEvent;
+import net.minecraftforge.fml.common.Mod;
+import net.minecraftforge.fml.event.config.ModConfigEvent;
+import net.minecraftforge.registries.ForgeRegistries;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+// An example config class. This is not required, but it's a good idea to have one to keep your config organized.
+// Demonstrates how to use Forge's config APIs
+@Mod.EventBusSubscriber(modid = ExampleMod.MODID, bus = Mod.EventBusSubscriber.Bus.MOD)
+public class Config
+{
+    private static final ForgeConfigSpec.Builder BUILDER = new ForgeConfigSpec.Builder();
+
+    private static final ForgeConfigSpec.BooleanValue LOG_DIRT_BLOCK = BUILDER
+            .comment("Whether to log the dirt block on common setup")
+            .define("logDirtBlock", true);
+
+    private static final ForgeConfigSpec.IntValue MAGIC_NUMBER = BUILDER
+            .comment("A magic number")
+            .defineInRange("magicNumber", 42, 0, Integer.MAX_VALUE);
+
+    public static final ForgeConfigSpec.ConfigValue<String> MAGIC_NUMBER_INTRODUCTION = BUILDER
+            .comment("What you want the introduction message to be for the magic number")
+            .define("magicNumberIntroduction", "The magic number is... ");
+
+    // a list of strings that are treated as resource locations for items
+    private static final ForgeConfigSpec.ConfigValue<List<? extends String>> ITEM_STRINGS = BUILDER
+            .comment("A list of items to log on common setup.")
+            .defineListAllowEmpty(Collections.singletonList("items"), () -> List.of("minecraft:iron_ingot"), Config::validateItemName);
+
+    static final ForgeConfigSpec SPEC = BUILDER.build();
+
+    public static boolean logDirtBlock;
+    public static int magicNumber;
+    public static String magicNumberIntroduction;
+    public static Set<Item> items;
+
+    private static boolean validateItemName(final Object obj)
+    {
+        return obj instanceof final String itemName && ForgeRegistries.ITEMS.containsKey(new ResourceLocation(itemName));
+    }
+
+    @SubscribeEvent
+    static void onLoad(final ModConfigEvent event)
+    {
+        logDirtBlock = LOG_DIRT_BLOCK.get();
+        magicNumber = MAGIC_NUMBER.get();
+        magicNumberIntroduction = MAGIC_NUMBER_INTRODUCTION.get();
+
+        // convert the list of strings into a set of items
+        items = ITEM_STRINGS.get().stream()
+                .map(itemName -> ForgeRegistries.ITEMS.getValue(new ResourceLocation(itemName)))
+                .collect(Collectors.toSet());
+    }
+}

--- a/com/example/examplemod/ExampleMod.java
+++ b/com/example/examplemod/ExampleMod.java
@@ -1,0 +1,101 @@
+package com.example.examplemod;
+
+import com.mojang.logging.LogUtils;
+import net.minecraft.client.Minecraft;
+import net.minecraft.world.item.BlockItem;
+import net.minecraft.world.item.CreativeModeTab;
+import net.minecraft.world.item.Item;
+import net.minecraft.world.level.block.Block;
+import net.minecraft.world.level.block.Blocks;
+import net.minecraft.world.level.block.state.BlockBehaviour;
+import net.minecraft.world.level.material.Material;
+import net.minecraftforge.api.distmarker.Dist;
+import net.minecraftforge.common.MinecraftForge;
+import net.minecraftforge.eventbus.api.IEventBus;
+import net.minecraftforge.eventbus.api.SubscribeEvent;
+import net.minecraftforge.fml.ModLoadingContext;
+import net.minecraftforge.fml.InterModComms;
+import net.minecraftforge.fml.common.Mod;
+import net.minecraftforge.fml.config.ModConfig;
+import net.minecraftforge.fml.event.lifecycle.FMLClientSetupEvent;
+import net.minecraftforge.fml.event.lifecycle.FMLCommonSetupEvent;
+import net.minecraftforge.fml.event.lifecycle.InterModEnqueueEvent;
+import net.minecraftforge.fml.event.lifecycle.InterModProcessEvent;
+import net.minecraftforge.event.server.ServerStartingEvent;
+import net.minecraftforge.fml.javafmlmod.FMLJavaModLoadingContext;
+import net.minecraftforge.registries.DeferredRegister;
+import net.minecraftforge.registries.ForgeRegistries;
+import net.minecraftforge.registries.RegistryObject;
+import org.slf4j.Logger;
+
+// The value here should match an entry in the META-INF/mods.toml file
+@Mod(ExampleMod.MODID)
+public class ExampleMod
+{
+    // Define mod id in a common place for everything to reference
+    public static final String MODID = "examplemod";
+    // Directly reference a slf4j logger
+    private static final Logger LOGGER = LogUtils.getLogger();
+    // Create a Deferred Register to hold Blocks which will all be registered under the "examplemod" namespace
+    public static final DeferredRegister<Block> BLOCKS = DeferredRegister.create(ForgeRegistries.BLOCKS, MODID);
+    // Create a Deferred Register to hold Items which will all be registered under the "examplemod" namespace
+    public static final DeferredRegister<Item> ITEMS = DeferredRegister.create(ForgeRegistries.ITEMS, MODID);
+
+    // Creates a new Block with the id "examplemod:example_block", combining the namespace and path
+    public static final RegistryObject<Block> EXAMPLE_BLOCK = BLOCKS.register("example_block", () -> new Block(BlockBehaviour.Properties.of(Material.STONE)));
+    // Creates a new BlockItem with the id "examplemod:example_block", combining the namespace and path
+    public static final RegistryObject<Item> EXAMPLE_BLOCK_ITEM = ITEMS.register("example_block", () -> new BlockItem(EXAMPLE_BLOCK.get(), new Item.Properties().tab(CreativeModeTab.TAB_BUILDING_BLOCKS)));
+
+    public ExampleMod()
+    {
+        IEventBus modEventBus = FMLJavaModLoadingContext.get().getModEventBus();
+
+        // Register the commonSetup method for modloading
+        modEventBus.addListener(this::commonSetup);
+
+        // Register the Deferred Register to the mod event bus so blocks get registered
+        BLOCKS.register(modEventBus);
+        // Register the Deferred Register to the mod event bus so items get registered
+        ITEMS.register(modEventBus);
+
+        // Register ourselves for server and other game events we are interested in
+        MinecraftForge.EVENT_BUS.register(this);
+
+        // Register our mod's ForgeConfigSpec so that Forge can create and load the config file for us
+        ModLoadingContext.get().registerConfig(ModConfig.Type.COMMON, Config.SPEC);
+    }
+
+    private void commonSetup(final FMLCommonSetupEvent event)
+    {
+        // Some common setup code
+        LOGGER.info("HELLO FROM COMMON SETUP");
+
+        if (Config.logDirtBlock)
+            LOGGER.info("DIRT BLOCK >> {}", ForgeRegistries.BLOCKS.getKey(Blocks.DIRT));
+
+        LOGGER.info(Config.magicNumberIntroduction + Config.magicNumber);
+
+        Config.items.forEach((item) -> LOGGER.info("ITEM >> {}", item.toString()));
+    }
+
+    // You can use SubscribeEvent and let the Event Bus discover methods to call
+    @SubscribeEvent
+    public void onServerStarting(ServerStartingEvent event)
+    {
+        // Do something when the server starts
+        LOGGER.info("HELLO from server starting");
+    }
+
+    // You can use EventBusSubscriber to automatically register all static methods in the class annotated with @SubscribeEvent
+    @Mod.EventBusSubscriber(modid = MODID, bus = Mod.EventBusSubscriber.Bus.MOD, value = Dist.CLIENT)
+    public static class ClientModEvents
+    {
+        @SubscribeEvent
+        public static void onClientSetup(FMLClientSetupEvent event)
+        {
+            // Some client setup code
+            LOGGER.info("HELLO FROM CLIENT SETUP");
+            LOGGER.info("MINECRAFT NAME >> {}", Minecraft.getInstance().getUser().getName());
+        }
+    }
+}

--- a/compose.yaml
+++ b/compose.yaml
@@ -5,14 +5,15 @@ services:
       args:
         MC_VERSION: ${MC_VERSION}
         FORGE_VERSION: ${FORGE_VERSION}
-        REPO: ${REPO}
-      ssh:
-        - default
       dockerfile: Dockerfile
     container_name: mc-dev
-    env_file: .env
     volumes:
-      - mod_build:/usr/local/proj/build/libs
+      - type: volume
+        source: mod_build
+        target: /usr/local/proj/build/libs
+      - type: bind
+        source: ./com
+        target: /usr/local/proj/src/main/java/com
   server:
     container_name: mc-server
     image: itzg/minecraft-server


### PR DESCRIPTION
This repo is intended as a boilerplate for development, so it makes more sense to utilize bind mounts to import code instead of SSH for multiple reasons:
- Using SSH to bring your repo into the container banked on your repo being based off of the forge MDK. This assumption could lead to things breaking.
- Simplifies setup as you don't have to worry about setting up SSH on your machine. Less host setup = a more contained solution.